### PR TITLE
Remove dash from `crc32` require

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  */
 
 require('./blob.toArrayBuffer')
-let crc32 = require('./crc-32')
+let crc32 = require('./crc32')
 
 
 // Used for fast-ish conversion between uint8s and uint32s/int32s.


### PR DESCRIPTION
- the filename's `crc32.js`