### PR TITLE
Fix browser example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Metadata in PNG files: https://dev.exiv2.org/projects/exiv2/wiki/The_Metadat
 
   //Browser
   const blob = await loadFileAsBlob('1000ppcm.png');
-  const buffer = await blob.arrayBuffer();
+  const buffer = new Uint8Array(await blob.arrayBuffer());
 
   //NodeJS
   const buffer = fs.readFileSync('1000ppcm.png')


### PR DESCRIPTION
The result returned by "await [blob.arrayBuffer()](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer)" is an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).

It is an array of bytes, often referred to in other languages as a "byte array". You cannot directly manipulate the contents of an ArrayBuffer; instead, you create one of the [typed array objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) or a [DataView](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView) object which represents the buffer in a specific format, and use that to read and write the contents of the buffer.